### PR TITLE
add user fetch methods

### DIFF
--- a/KDG.Connector.CRM.csproj
+++ b/KDG.Connector.CRM.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
      <PackageId>KDG-Net-Zoho-CRM</PackageId>
-     <Version>0.0.2</Version>
+     <Version>0.0.3</Version>
      <Authors>Kyle David Group</Authors>
      <Company>Kyle David Group</Company>
      <Description>A wrapper for common Zoho CRM functionalities</Description>

--- a/Models/ApiResponse.cs
+++ b/Models/ApiResponse.cs
@@ -11,4 +11,11 @@ namespace KDG.Zoho.CRM.Models
         public IEnumerable<T> Emails { get; set; }
         public ApiResponseInfo info { get; set; }
     }
+
+    public struct UsersApiResponse<T>
+    {
+        public IEnumerable<T> Users { get; set; }
+        public ApiResponseInfo info { get; set; }
+
+    }
 }

--- a/Services/CRMConnector.cs
+++ b/Services/CRMConnector.cs
@@ -22,6 +22,7 @@ namespace KDG.Zoho.CRM.Services
     private long? _tokenExpiration;
     private IClock _clock;
     private string _tokenUri = "https://accounts.zoho.com/oauth/v2/token";
+    private string _userModule = "users";
 
     private AccessToken<KDG.Zoho.CRM.Models.ZohoAccessToken> AccessTokenGenerator()
     {
@@ -90,6 +91,37 @@ namespace KDG.Zoho.CRM.Services
       var response = await Send<ApiResponse<T>>(HttpMethod.Get, $"{module}/{id}", config);
 
       return response.data.FirstOrDefault();
+    }
+
+    public async Task<T?> GetUserRecord<T>(string id, IEnumerable<string> fields)
+    {
+      var config = new ApiParams()
+      {
+        urlParams = new Dictionary<string, string?>()
+        {
+          ["ids"] = id,
+          ["fields"] = String.Join(",", fields)
+        }
+      };
+      var response = await Send<UsersApiResponse<T>>(HttpMethod.Get, $"{_userModule}", config);
+
+      return response.Users.FirstOrDefault();
+    }
+
+    public async Task<IEnumerable<T>> GetUserRecords<T>(IEnumerable<string> ids, IEnumerable<string> fields)
+    {
+      var config = new ApiParams()
+      {
+        urlParams = new Dictionary<string, string?>()
+        {
+          ["ids"] = String.Join(",", ids),
+          ["fields"] = String.Join(",", fields)
+        }
+      };
+
+      var response = await Send<UsersApiResponse<T>>(HttpMethod.Get, $"{_userModule}", config);
+
+      return response.Users;
     }
 
     public async Task<List<T>> GetEmailRecords<T>(string module)


### PR DESCRIPTION
Allows the crm connector to fetch records from the users api, which returns its output under an object called users rather than data like most other crm apis.